### PR TITLE
refactor: use Number.isNaN instead of isNaN

### DIFF
--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -31,7 +31,7 @@ export function convertToUnit(
 ): string | undefined {
   if (str == null || str === '') {
     return undefined;
-  } else if (isNaN(+str!)) {
+  } else if (Number.isNaN(+str!)) {
     return String(str);
   } else if (!isFinite(+str!)) {
     return undefined;


### PR DESCRIPTION
From MDN, it is suggested to use `Number.isNaN` instead of globally `isNaN`.

![image](https://user-images.githubusercontent.com/20434351/147619453-2e5698ed-ef73-42cc-9e18-904fc617dca1.png)

References: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/isNaN#confusing_special-case_behavior
